### PR TITLE
Add life icons to show remaining lives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ your own.
 ### Stage 3 – Core Game Features
 
 - [ ] Implement score tracking and on‑screen display.
-- [ ] Track player lives and end the game when lives reach zero.
+- [x] Track player lives and end the game when lives reach zero.
 - [ ] Introduce multiple waves or levels of enemies.
 - [ ] Add increasing difficulty and varied enemy behaviors.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Galaga Clone
 
-This simple clone of the classic Galaga arcade game uses sprite assets found in
-`space_starter_kit`. Run it with:
-
+This simple clone of the classic Galaga arcade game uses sprite assets found in `space_starter_kit`. This version tracks your remaining lives, shown as small ships at the bottom of the screen. You start with three ships in total. Run it with:
 ```bash
 python3 galaga.py
 ```

--- a/galaga.py
+++ b/galaga.py
@@ -28,6 +28,7 @@ def main():
     player_image = load_sprite("starship.svg", 40, 30)
     bullet_image = load_sprite("projectile1.svg", 5, 15)
     enemy_image = load_sprite("ufo.svg", 30, 20)
+    life_image = load_sprite("starship.svg", 30, 20)
 
     class Player(pygame.sprite.Sprite):
         def __init__(self, double=False):
@@ -194,6 +195,10 @@ def main():
         if beam_rect:
             pygame.draw.rect(screen, (0, 255, 255), beam_rect)
 
+        for i in range(lives):
+            x = 10 + i * (life_image.get_width() + 10)
+            y = SCREEN_HEIGHT - life_image.get_height() - 5
+            screen.blit(life_image, (x, y))
         pygame.display.flip()
         clock.tick(60)
 


### PR DESCRIPTION
## Summary
- show remaining lives as small ships at the bottom of the screen
- document multiple lives in `README.md`
- mark life tracking complete in development checklist

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 galaga.py` *(fails: ModuleNotFoundError: No module named 'pygame')*