### PR TITLE
Improve capture trigger

### DIFF
--- a/galaga.py
+++ b/galaga.py
@@ -13,6 +13,7 @@ CAPTURE_SPEED = 2
 DIVE_SPEED = 3
 DIVE_PROBABILITY = 0.005
 ENEMY_BULLET_SPEED = 4
+CAPTURE_ALIGN_DISTANCE = 30
 
 pygame.init()
 
@@ -217,7 +218,8 @@ def main():
 
         # Boss capture behaviour when aligned at the top
         if boss.is_boss and not boss.capturing and not boss.has_player:
-            if abs(boss.rect.centerx - player.rect.centerx) < 5 and boss.rect.y <= boss.start_pos.y:
+            aligned = abs(boss.rect.centerx - player.rect.centerx) < CAPTURE_ALIGN_DISTANCE
+            if aligned and boss.rect.y <= boss.start_pos.y:
                 boss.capturing = True
 
         beam_rects = []


### PR DESCRIPTION
## Summary
- let the boss begin capture when within a wider alignment range
- expose `CAPTURE_ALIGN_DISTANCE` constant for easier tweaking

## Testing
- `python3 -m py_compile galaga.py`