### PR TITLE
Fix last enemy returning to offscreen position

### DIFF
--- a/galaga.py
+++ b/galaga.py
@@ -238,11 +238,13 @@ def main():
         enemy_bullets.update()
 
         # Update enemies
-        formation_offset_x += formation_speed * enemy_direction
+        moving_enemies = [e for e in enemies if not e.diving and not e.returning]
+        if moving_enemies:
+            formation_offset_x += formation_speed * enemy_direction
         move_down = False
         for enemy in enemies:
             enemy.update(enemy_direction, formation_offset_x)
-            if not enemy.diving and not enemy.returning:
+            if enemy in moving_enemies:
                 if enemy.rect.right > SCREEN_WIDTH or enemy.rect.left < 0:
                     move_down = True
         if move_down:


### PR DESCRIPTION
## Summary
- when all enemies are diving the formation kept moving, causing the last one to return off-screen
- stop updating the formation offset when no enemies are in formation

## Testing
- `python3 galaga.py` *(fails: ModuleNotFoundError: No module named 'pygame')*